### PR TITLE
セキュリティ対策

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,6 +1,6 @@
 class ArtistsController < ApplicationController
 
-	before_action :caddmin_user_check, only: [:new, :create]
+	before_action :addmin_user_check, only: [:new, :create]
 	
 	def destroy
 	end

--- a/app/controllers/purchase_histories_controller.rb
+++ b/app/controllers/purchase_histories_controller.rb
@@ -2,11 +2,7 @@ class PurchaseHistoriesController < ApplicationController
 
   before_action :check_check, only: [:new]
   before_action :current_user_check, only: [:show]
-
-
-
- 
- 
+  before_action :nil_check, only: [:new]
 
 
 	def index
@@ -89,6 +85,13 @@ class PurchaseHistoriesController < ApplicationController
         if carts.count == 0
           redirect_to carts_path, notice: '何もえらんでないじゃん！ぷぷぷ'
         end
+    end
+
+    def nil_check
+      carts = Cart.all
+      if current_user.carts == nil
+        redirect_to carts_path, notice: 'カゴからっぽじゃん！ぷぷぷ'
+      end
     end
 
     def current_user_check

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,9 @@ class UsersController < ApplicationController
 
 	before_action :current_user_check, only: [:edit, :update, :destroy]
 
+	def admin
+	end
+
 	def index
     @users = User.all.page(params[:page]).reverse_order
 

--- a/app/views/products/top.html.erb
+++ b/app/views/products/top.html.erb
@@ -4,9 +4,3 @@
 <p>最近はストリーミングで音楽を楽しむことも多くなってきたかと思います。</p><br>
 <p>そんな時代にあえて、CDで音楽を楽しみませんか？</p><br>
 <p>それもジャケ買いで！！</p><br>
-
-<% if administrator_signed_in? || user_signed_in? %>
-	<p>楽しんでいただけてますか？</p>
-<% else %>
-	<p><%= link_to '管理者用ログイン', new_administrator_session_path %></p>
-<% end %>

--- a/app/views/users/admin.html.erb
+++ b/app/views/users/admin.html.erb
@@ -1,0 +1,1 @@
+<p><%= link_to '管理者用ログイン', new_administrator_session_path %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
 
 root 'products#top'
 
+get 'kajikaji/nosunosu' => 'users#admin'
+
 devise_for :administrators
 devise_for :users, controllers: { registrations: 'users/registrations' }
 # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
セキュリティ対策のため、管理者要ログインのリンクを別のページに設け、urlを知っている人しか、管理者用ログインのリンクのあるページに行けないようにしました。